### PR TITLE
Don't reset bomb timer, when dropping on another bomb

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'groovy'
 apply plugin: 'application'
 apply plugin: 'com.jfrog.artifactory'
 
-version = '1.0.5'
+version = '1.0.6'
 
 mainClassName = 'io.riddles.hackman2.HackMan2'
 sourceCompatibility = 1.8

--- a/src/java/io/riddles/hackman2/game/board/HackMan2Board.java
+++ b/src/java/io/riddles/hackman2/game/board/HackMan2Board.java
@@ -215,7 +215,15 @@ public class HackMan2Board extends Board {
     }
 
     public void dropBomb(Point coordinate, int ticks) {
-        this.bombs.put(coordinate.toString(), new Bomb(coordinate, ticks));
+        boolean drop = true;
+        if (this.bombs.containsKey(coordinate.toString()) &&
+                this.bombs.get(coordinate.toString()).getTicks() != null &&
+                ticks > this.bombs.get(coordinate.toString()).getTicks()) {
+            drop = false;
+        }
+        if (drop) {
+            this.bombs.put(coordinate.toString(), new Bomb(coordinate, ticks));
+        }
     }
 
     public ArrayList<Enemy> getEnemies() {


### PR DESCRIPTION
Problem:
when a player puts a bomb on top of another ticking bomb, the timer will be set to the new one.
In [round 211](https://booking.riddles.io/competitions/ms.-hack-man/matches/e87771dd-7ca6-40bf-b600-870712e6f006) player0 places a bomb with timer 2 to hit player 1. But by placing another bomb, player1 can escape.

I see another problem, but am not sure if this needs to be fixed: when a player wants to place a bomb on an unarmed one, he won't be able to pick up the other one, as the [bomb placing comes before the pickup](https://github.com/riddlesio/hack-man-2-engine/blob/development/src/java/io/riddles/hackman2/game/processor/HackMan2Processor.java#L118-L121). Changing that would either require to split the movement in two parts (move, pick up items, place bombs) or to change the way, bombs are stored to allow for multiple bombs on the same field.


In the pull request I don't place another bomb, if the timer is bigger. There is no need for two bombs, as one of them would get triggered by the explosion of the other.
Please make sure, that my patch actually works, as I didn't check it ;)


Edit:
Here is an example of dropping a bomb on top of an unarmed one: [round 173](https://booking.riddles.io/competitions/ms.-hack-man/matches/04123743-8e26-4d09-9568-c781240324e0). Although the animation implies differently, there is no unarmed bomb left, just the ticking one.